### PR TITLE
Modify the sample markdown to link on click

### DIFF
--- a/mergechance/templates/chance.html
+++ b/mergechance/templates/chance.html
@@ -68,8 +68,7 @@
     <a class="pure-u-1-24"></a>
     <pre class="pure-u-22-24">
         <code class="markdown">
-            ![merge-chance-badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fmerge-chance.info%2Fbadge%3Frepo%3D{{repo | urlencode}})
-            [merge-chance-link](https://merge-chance.info/target?repo={{repo | urlencode}})
+            [![merge-chance-badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fmerge-chance.info%2Fbadge%3Frepo%3D{{repo | urlencode}})](https://merge-chance.info/target?repo={{repo | urlencode}})
         </code>
     </pre>
 </div>


### PR DESCRIPTION
I've modified the sample markdown so that the image is inside the link, this means that the image itself acts as a link and when clicked it will go to the results page.
Most badges work this way.
`[![badge-alt-text](https://badge.com/image.png)](https://badge.com)`
